### PR TITLE
Updated the explicit style example

### DIFF
--- a/docs/src/model.md
+++ b/docs/src/model.md
@@ -92,7 +92,8 @@ x_(rng) = rand(rng) > 0.5
 `x_` is just a normal julia function.  We could sample from it by passing in the `GLOBAL_RNG`
 
 ```julia
-julia> x_(Base.Random.GLOBAL_RNG)
+julia> using Random
+julia> x_(Random.GLOBAL_RNG)
 true
 ```
 


### PR DESCRIPTION
I am new to Julia so I do not know if the example is merely out of date, but to get this to work I had to import the `Random` package explicitly.

```jl
using Omega
using Random
x_(rng) = rand(rng) > 0.5
x_(Random.GLOBAL_RNG)
```

`Random` doesn't seem to be in `Base`.